### PR TITLE
Update task_dc_na_ontap_rest.adoc

### DIFF
--- a/task_dc_na_ontap_rest.adoc
+++ b/task_dc_na_ontap_rest.adoc
@@ -44,11 +44,10 @@ To create a local account for Data Infrastructure Insights at the cluster level,
  security login rest-role create -role {role name} -api /api -access readonly
  security login rest-role create -role {role name} -api /api/cluster/agents -access all
  vserver services web access create -name spi -role {role name} -vserver {vserver name as retrieved above}
- security login create -user-or-group-name {username} -application http -authentication-method password -role {role name}
 
 . Create the read-only user using the following command. Once you have executed the create command, you will be prompted to enter a password for this user.
 
- security login create -username ci_user -application http -authentication-method password -role ci_readonly
+ security login create -user-or-group-name {username} -application http -authentication-method password -role {role name}
  
 If AD/LDAP account is used, the command should be 
 


### PR DESCRIPTION
1) Moved command to create a user from "Create a role" section down to "Create a read-only user" section as thats where it belongs.
2) Replaced the existing command in "Create a read-only user" section because it contained a bad parameter name `-username` and the variables are not consistent with previous entries.