### PR TITLE
Update task_dc_brocade_rest.adoc

### DIFF
--- a/task_dc_brocade_rest.adoc
+++ b/task_dc_brocade_rest.adoc
@@ -14,7 +14,7 @@ summary: Configuring Brocade FOS REST data collector.
 :imagesdir: ./media/
 
 [.lead] 
-Data Infrastructure Insights uses the Brocade FOS REST collector to discover inventory and performance for Brocade switch devices running FabricOS (FOS) firmware 8.2 and later. 
+Data Infrastructure Insights uses the Brocade FOS REST collector to discover inventory and performance for Brocade switch devices running FabricOS (FOS) firmware 8.2 and later. Please note that early 8.2 FOS releases may have REST API bugs, and we would recommend running the latest possible FOS release your platform supports.   
 
 Please note: FOS' default "user" level is insufficiently powerful for Data Infrastructure Insights to view all the logical aspects of a device - we need a user account with the "Chassis Role" enabled, as well as permissions on all the Virtual Fabrics configured on a switch. 
 
@@ -92,6 +92,8 @@ Some things to try if you encounter problems with this data collector:
 |The Test feature warns me that a protocol is inaccessible
 
 |A given Brocade FOS 8.2+ device will only want to speak on HTTP or HTTPS - if a switch has a digital certificate installed, the switch will throw HTTP errors if one attempts to communicate to it with unencrypted HTTP versus HTTPS. The test feature attempts communication with both HTTP and HTTPS - if the Test tells you that one protocol passes, you can safely save the collector and not worry that the other protocol was unsuccessful - the collector will attempt both protocols during collection, and only fail if neither works.
+
+|Error: Inventory fails with 401 Unauthorized...Invalid Session Key...|This is distinct bug within some very early 8.2 FOS releases lie 8.2.1c that do NOT properly support HTTP basic authentication. Upgrade to a later 8.2 or 9.* release
 
 |Error: “Data Infrastructure Insights received Invalid Chassis Role” |Check that the user configured in this data source has been granted the chassis role permission.
 |Error: "Mismatched Chassis IP Address" |Change the data source configuration to use chassis IP address.


### PR DESCRIPTION
discourse on the session key bug in some early 8.2 FOS firmware